### PR TITLE
fix(doc): BOARD_NAME parameter case

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You have to specify a board name as first env variable (BOARD_NAME), it is lower
 ## Build the Firmware
 1. Run the container, specifying the path to the OpenTX source as a mount volume:
 
-   `docker run --rm -it -e "BOARD_NAME=I6X" -v [OpenTX Source Path]:/opentx ajjjjjjjj/opentx-docker-i6x`
+   `docker run --rm -it -e "BOARD_NAME=i6x" -v [OpenTX Source Path]:/opentx ajjjjjjjj/opentx-docker-i6x`
 
 The compiled firmware image will be placed in the root of the source directory when the build has finished.  
 


### PR DESCRIPTION
The BOARD_NAME parameter is case sensitive - value given needs to match the case used in `build-fw.py`

https://github.com/ajjjjjjjj/opentx-docker-build/blob/cc63b2c6ef70d9f2c05169c4ee68a2c594f502d3/build-fw.py#L160